### PR TITLE
Private methods

### DIFF
--- a/pipeline.coffee
+++ b/pipeline.coffee
@@ -102,9 +102,12 @@ pipeline =
 
       if key in after then throw new Error "store \"#{key}\" waits for itself"
 
+      reservedKeys = _.intersection(_.keys(options), ['stores', 'key', 'trigger', 'get', 'update'])
 
+      unless _.isEmpty reservedKeys then _.each reservedKeys, (reservedKey) ->
+        throw new Error "In \"#{key}\" Store: \"#{reservedKey}\" is a reserved key and cannot be used."
 
-      _context = _.omit options, ['api', 'actions', 'stores', 'key', 'trigger', 'get', 'update']
+      _context = _.omit options,['api', 'actions']
 
       _.each _context, (prop, key) -> if _.isFunction(prop) then _context[key] = prop.bind(_context)
 


### PR DESCRIPTION
This moves any non-reserved properties from the options hash onto the `_context`.   If those properties are functions, then they are bound to `_context.`  

We may want to restrict these to only be functions to avoid the creation of private state that isn't managed by `@update`, `@get`, etc.   

We may also wan to throw an error on omitted properties.  
